### PR TITLE
Adapt new schema to invitation flow

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -3,11 +3,11 @@ class Admin::InvitationsController < ApplicationController
   before_action :require_sign_in_as_admin
 
   def new
-    @invitation = Invitation.new
+    @invitation = current_tournament.invitations.build
   end
 
   def create
-    @invitation = Invitation.new(invitation_params)
+    @invitation = current_tournament.invitations.build(invitation_params)
 
     if @invitation.save
       Admin::MemberMailer.invitation_email(@invitation).deliver_now

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -3,11 +3,11 @@ class Admin::MembersController < ApplicationController
   before_action :require_invitation_token
 
   def new
-    @admin = Admin.new(email: params[:email])
+    @admin = Tournament.find(params[:tournament_id]).admins.build(email: params[:email])
   end
 
   def create
-    @admin = Admin.new(admin_params)
+    @admin = Tournament.find(params[:tournament_id]).admins.build(admin_params)
     if @admin.save
       @invitation.update_attribute(:signed_up, true)
       admin_sign_in @admin

--- a/app/helpers/admin/sessions_helper.rb
+++ b/app/helpers/admin/sessions_helper.rb
@@ -10,4 +10,12 @@ module Admin::SessionsHelper
   def admin_sign_out
     session.delete(:admin_id)
   end
+
+  def current_admin
+    @current_admin ||= Admin.find_by(id: session[:admin_id])
+  end
+
+  def current_tournament
+    @current_tournament ||= current_admin.tournament
+  end
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,4 +1,5 @@
 class Admin < ApplicationRecord
+  belongs_to :tournament
   has_secure_password
 
   validates :email,    presence: true, length: { maximum: 255 },

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,4 +1,5 @@
 class Invitation < ApplicationRecord
+  belongs_to :tournament
   attr_accessor :invitation_token
   before_create :create_invitation_digest
 

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -1,2 +1,4 @@
 class Tournament < ApplicationRecord
+  has_many :invitations
+  has_many :admins
 end

--- a/app/views/admin/member_mailer/invitation_email.text.erb
+++ b/app/views/admin/member_mailer/invitation_email.text.erb
@@ -1,5 +1,5 @@
-第72回競技かるた京都大会
+かるた大会管理サイト
 
-当サイトの管理者として招待されています。以下のリンクより管理者登録を行ってください。
+<%= @invitation.tournament.name %>の運営管理者として招待されています。以下のリンクより登録を行ってください。
 
-<%= admin_new_sign_up_url(@invitation.invitation_token, email: @invitation.email) %>
+<%= admin_new_sign_up_url(@invitation.invitation_token, tournament_id: @invitation.tournament_id, email: @invitation.email) %>

--- a/db/migrate/20181123084417_add_reference_to_invitation.rb
+++ b/db/migrate/20181123084417_add_reference_to_invitation.rb
@@ -1,0 +1,5 @@
+class AddReferenceToInvitation < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :invitations, :tournament, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_21_023234) do
+ActiveRecord::Schema.define(version: 2018_11_23_084417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,8 @@ ActiveRecord::Schema.define(version: 2018_11_21_023234) do
     t.boolean "signed_up", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "tournament_id"
+    t.index ["tournament_id"], name: "index_invitations_on_tournament_id"
   end
 
   create_table "players", force: :cascade do |t|
@@ -107,6 +109,7 @@ ActiveRecord::Schema.define(version: 2018_11_21_023234) do
   end
 
   add_foreign_key "admins", "tournaments"
+  add_foreign_key "invitations", "tournaments"
   add_foreign_key "players", "teams"
   add_foreign_key "tournament_classes", "tournaments"
   add_foreign_key "tournament_classes_ranks", "tournament_classes"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,8 +8,15 @@ kyoto = Team.create!(
   activated_at: Time.zone.now
 )
 
-shiga = Tournament.create!(
-  name: "滋賀県大会",
-  schedule: Time.zone.local(2019, 3, 21),
-  venue: "近江勧学館"
+tournament = Tournament.create!(
+  name: ENV["TOURNAMENT_NAME"],
+  schedule: ENV["TOURNAMENT_SCHEDULE"],
+  venue: ENV["TOURNAMENT_VENUE"]
+)
+
+initial_admin = tournament.admins.create!(
+  name: ENV["ADMIN_NAME"],
+  email: ENV["ADMIN_EMAIL"],
+  password: "password",
+  password_confirmation: "password"
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,6 +17,6 @@ tournament = Tournament.create!(
 initial_admin = tournament.admins.create!(
   name: ENV["ADMIN_NAME"],
   email: ENV["ADMIN_EMAIL"],
-  password: "password",
-  password_confirmation: "password"
+  password: ENV["ADMIN_PASS"],
+  password_confirmation: ENV["ADMIN_PASS"]
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,9 @@ kyoto = Team.create!(
   activated: true,
   activated_at: Time.zone.now
 )
+
+shiga = Tournament.create!(
+  name: "滋賀県大会",
+  schedule: Time.zone.local(2019, 3, 21),
+  venue: "近江勧学館"
+)

--- a/test/fixtures/admins.yml
+++ b/test/fixtures/admins.yml
@@ -2,3 +2,4 @@ ryo:
   name: 池谷涼
   email: ryo@example.com
   password_digest: <%= BCrypt::Password.create('password') %>
+  tournament: shiga

--- a/test/fixtures/tournaments.yml
+++ b/test/fixtures/tournaments.yml
@@ -1,0 +1,4 @@
+shiga:
+  name: 滋賀県大会
+  schedule: <%= Time.zone.local(2019, 3, 21) %>
+  venue: "近江勧学館"


### PR DESCRIPTION
滋賀県大会を`tournaments`テーブルの1レコードとして扱うことになったので, 各コードをそれに対応させていきます.
まずこのPRでは管理者招待の一連の流れを修正しました.
(`admin`としてログインしている場合はassociationを通して大会情報が取得でき, どんな修正をすればいいかイメージがつきやすかったので)

具体的には以下を行いました.

- `invitations`テーブルに`tournament_id`カラムを追加.
- テストコードの見直し(テストコードの修正自体はありませんでした)
- 各モデルにassociationを指定
- ヘルパーメソッドやfixtureを追加
- associationの整合性がつくようにコントローラ等のコードを修正