### PR TITLE
Static pages

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -3,5 +3,6 @@ class StaticPagesController < ApplicationController
   end
 
   def info
+    @tournament = Tournament.includes(:tournament_classes).first
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  def this_tournament
+  def default_tournament
     @tournament ||= Tournament.first
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def this_tournament
+    @tournament ||= Tournament.first
+  end
 end

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -1,4 +1,5 @@
 class Tournament < ApplicationRecord
   has_many :invitations
   has_many :admins
+  has_many :tournament_classes
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand navbar-dark bg-success">
   <div class="container">
-    <%= link_to "#{this_tournament.name}申込サイト", root_path, class: 'navbar-brand mr-auto' %>
+    <%= link_to "#{default_tournament.name}申込サイト", root_path, class: 'navbar-brand mr-auto' %>
     <ul class="navbar-nav">
       <li class="nav-item"><%= link_to "大会情報", info_path, class: 'nav-link' %></li>
       <li class="nav-item"><%= link_to "お問合せ", '#', class: 'nav-link' %></li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand navbar-dark bg-success">
   <div class="container">
-    <%= link_to "第72回競技かるた京都大会", root_path, class: 'navbar-brand mr-auto' %>
+    <%= link_to "#{this_tournament.name}申込サイト", root_path, class: 'navbar-brand mr-auto' %>
     <ul class="navbar-nav">
       <li class="nav-item"><%= link_to "大会情報", info_path, class: 'nav-link' %></li>
       <li class="nav-item"><%= link_to "お問合せ", '#', class: 'nav-link' %></li>

--- a/app/views/layouts/_header_admin.html.erb
+++ b/app/views/layouts/_header_admin.html.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand navbar-dark bg-success">
   <div class="container">
-    <%= link_to "#{this_tournament.name}管理者ページ", admin_root_path, class: 'navbar-brand mr-auto' %>
+    <%= link_to "#{default_tournament.name}管理者ページ", admin_root_path, class: 'navbar-brand mr-auto' %>
     <ul class="navbar-nav">
       <li class="nav-item"><%= link_to "大会情報", info_path, class: 'nav-link' %></li>
       <li class="nav-item"><%= link_to "お問合せ", '#', class: 'nav-link' %></li>

--- a/app/views/layouts/_header_admin.html.erb
+++ b/app/views/layouts/_header_admin.html.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand navbar-dark bg-success">
   <div class="container">
-    <%= link_to "第72回競技かるた京都大会管理者ページ", admin_root_path, class: 'navbar-brand mr-auto' %>
+    <%= link_to "#{this_tournament.name}管理者ページ", admin_root_path, class: 'navbar-brand mr-auto' %>
     <ul class="navbar-nav">
       <li class="nav-item"><%= link_to "大会情報", info_path, class: 'nav-link' %></li>
       <li class="nav-item"><%= link_to "お問合せ", '#', class: 'nav-link' %></li>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,4 +1,4 @@
-<h2 class="text-center mt-5">第72回競技かるた京都大会申込専用サイト</h2>
+<h2 class="text-center mt-5"><%= this_tournament.name %>申込サイト</h2>
 
 <div class="row justify-content-center">
   <div class="col-4">

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,4 +1,4 @@
-<h2 class="text-center mt-5"><%= this_tournament.name %>申込サイト</h2>
+<h2 class="text-center mt-5"><%= default_tournament.name %>申込サイト</h2>
 
 <div class="row justify-content-center">
   <div class="col-4">

--- a/app/views/static_pages/info.html.erb
+++ b/app/views/static_pages/info.html.erb
@@ -1,27 +1,27 @@
-<h1>京都大会詳細</h1>
+<h1><%= @tournament.name %>詳細</h1>
 
 <div class="row justify-content-center">
   <div class="col-6">
     <table class="table">
       <tr>
         <th>開催日</th>
-        <td>2018年12月16日</td>
+        <td><%= @tournament.schedule %></td>
       </tr>
       <tr>
         <th>当日締切時刻</th>
-        <td>9時15分</td>
+        <td></td>
       </tr>
       <tr>
         <th>開催級</th>
-        <td>C級, D級, E級</td>
+        <td></td>
       </tr>
       <tr>
         <th>主管かるた会</th>
-        <td>京都小倉かるた会</td>
+        <td></td>
       </tr>
       <tr>
         <th>大会会場</th>
-        <td>同志社女子大学今出川キャンパス純正館</td>
+        <td><%= @tournament.venue %></td>
       </tr>
       <tr>
         <th>第二会場</th>
@@ -29,14 +29,19 @@
       </tr>
       <tr>
         <th>参加費</th>
-        <td>C級 2000円<br>
-            D級 1800円<br>
-            E級 1200円
+        <td>
+          <table>
+            <% @tournament.tournament_classes.map do |t_class| %>
+              <tr>
+                <td><%= t_class.name %></td><td><%= t_class.fee %></td>
+              </tr>
+            <% end %>
+          </table>
         </td>
       </tr>
       <tr>
         <th>事前参加登録締切日</th>
-        <td>2018年11月17日</td>
+        <td></td>
       </tr>
     </table>
   </div>

--- a/app/views/static_pages/info.html.erb
+++ b/app/views/static_pages/info.html.erb
@@ -1,4 +1,4 @@
-<h1><%= @tournament.name %>詳細</h1>
+<h1><%= @tournament.name %>　大会情報</h1>
 
 <div class="row justify-content-center">
   <div class="col-6">
@@ -8,24 +8,8 @@
         <td><%= @tournament.schedule %></td>
       </tr>
       <tr>
-        <th>当日締切時刻</th>
-        <td></td>
-      </tr>
-      <tr>
-        <th>開催級</th>
-        <td></td>
-      </tr>
-      <tr>
-        <th>主管かるた会</th>
-        <td></td>
-      </tr>
-      <tr>
         <th>大会会場</th>
         <td><%= @tournament.venue %></td>
-      </tr>
-      <tr>
-        <th>第二会場</th>
-        <td>東寺洛南会館</td>
       </tr>
       <tr>
         <th>参加費</th>
@@ -39,10 +23,8 @@
           </table>
         </td>
       </tr>
-      <tr>
-        <th>事前参加登録締切日</th>
-        <td></td>
-      </tr>
     </table>
+
+    <p>詳細な大会情報は全日本かるた協会のホームページもしくはメーリングリストをご参照ください</p>
   </div>
 </div>


### PR DESCRIPTION
大会名をベタ書きしているところを修正しました.

今回は1大会だけを扱うので, `this_tournament`というヘルパーメソッドを用意し, ルートページでもヘッダーでも大会名を表示できるようにしました.

大会情報ページ`static_pages#info`は今後`tournament#show`にそのまま使えるような実装にしました.
大会情報のうち空欄になっているものは, データベース上に保持するかどうか迷っています.
各選手には, メーリスで流れる大会情報や, 全日協のページを見てもらうというのでも良さそうです.

ここまで実装していて疑問に感じたのは, `tournament_classes`の初期データをどのように与えるかです.
環境変数にHashを保存できるのかと調べてみると, 文字列として保存したものをRails側でパースする, という方法がでてきました.
このような方法で行うのがよいのでしょうか？