### PR TITLE
Improve entry flow

### DIFF
--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,7 +1,7 @@
 class Player < ApplicationRecord
   belongs_to :team
 
-  validates :rank_code,       presence: true,                          format: { with: /\A[C-E]\z/ }
+  validates :rank,            presence: true
   validates :team_id,         presence: true
   validate  :full_name_should_be_present, :full_name_kana_should_be_present,
             :full_name_should_have_maximum_length, :full_name_kana_should_have_maximum_length,

--- a/app/models/tournament_class.rb
+++ b/app/models/tournament_class.rb
@@ -1,2 +1,4 @@
 class TournamentClass < ApplicationRecord
+  belongs_to :tournament
+  has_and_belongs_to_many :players, join_table: :tournament_classes_players
 end

--- a/app/views/players/new.html.erb
+++ b/app/views/players/new.html.erb
@@ -1,63 +1,30 @@
-<h1><%= @rank %>級出場申込</h1>
+<h1><%= @tournament.name %> 出場申込</h1>
 
-<%= form_tag entries_team_path(rank: @rank) do %>
-  <% if @error_messages.present? %>
-    <div class="row justify-content-center">
-      <div class="col-8">
-        <p class="alert alert-danger text-center">入力エラーが存在します</p>
-      </div>
-    </div>
+<div class="row justify-content-center">
+  <div class="col-6">
+    <%= form_for @player, url: entries_team_path do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
 
-    <div class="row justify-content-center">
-      <div class="col-4">
-        <ul>
-          <% @error_messages.each do |msg| %>
-            <li><%= msg %></li>
-          <% end %>
-        </ul>
-      </div>
-    </div>
-  <% end %>
+      <%= label_tag :tournament_class_id, "出場級" %>
+      <%= select_tag :tournament_class_id, options_from_collection_for_select(@tournament.tournament_classes.all, :id, :name), class: 'form-control mb-4' %>
 
-  <div class="row justify-content-center">
-    <div class="col-8">
-      <table class="table table-bordered table-striped table-hover">
-        <tr>
-          <th>氏</th>
-          <th>名</th>
-          <th>氏(ふりがな)</th>
-          <th>名(ふりがな)</th>
-        </tr>
-        <% @players.each do |player| %>
-          <tr class="player-form-row <%= "bg-danger" if player.errors.full_messages.present? %>">
-            <td class="p-1"><%= text_field_tag 'players[][last_name]',       player.last_name,       class: 'form-control' %></td>
-            <td class="p-1"><%= text_field_tag 'players[][first_name]',      player.first_name,      class: 'form-control' %></td>
-            <td class="p-1"><%= text_field_tag 'players[][last_name_kana]',  player.last_name_kana,  class: 'form-control' %></td>
-            <td class="p-1"><%= text_field_tag 'players[][first_name_kana]', player.first_name_kana, class: 'form-control' %></td>
-          </tr>
-        <% end %>
-      </table>
-      <%= button_tag '入力欄を追加', type: 'button', class: 'btn btn-secondary', id: 'add_form_button' %>
-      <%= submit_tag '参加申込', class: 'btn btn-primary btn-block mt-4' %>
-    </div>
+      <%= f.label :last_name %>
+      <%= f.text_field :last_name, class: 'form-control mb-4' %>
+      
+      <%= f.label :first_name %>
+      <%= f.text_field :first_name, class: 'form-control mb-4' %>
+      
+      <%= f.label :last_name_kana %>
+      <%= f.text_field :last_name_kana, class: 'form-control mb-4' %>
+      
+      <%= f.label :first_name_kana %>
+      <%= f.text_field :first_name_kana, class: 'form-control mb-4' %>
+      
+      <%= f.label :rank %>
+      <%= f.select :rank, [["無段", 0], ["初段", 1]], {}, class: 'form-control mb-4' %>
+
+
+      <%= f.submit "参加登録", class: 'btn btn-block btn-primary' %>
+    <% end %>
   </div>
-<% end %>
-
-<script type="text/html", id="form_template">
-    <td class="p-1"><%= text_field_tag 'players[][last_name]',       nil, class: 'form-control' %></td>
-    <td class="p-1"><%= text_field_tag 'players[][first_name]',      nil, class: 'form-control' %></td>
-    <td class="p-1"><%= text_field_tag 'players[][last_name_kana]',  nil, class: 'form-control' %></td>
-    <td class="p-1"><%= text_field_tag 'players[][first_name_kana]', nil, class: 'form-control' %></td>
-</script>
-
-<script>
-  $(function(){
-    var button   = $('#add_form_button');
-    button.click(function(){
-      var template = $('#form_template').html();
-      var table    = $('table');
-      var row      = $('<tr>').html(template)
-      table.append(row);
-    });
-  });
-</script>
+</div>

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -17,6 +17,7 @@ ja:
         first_name_kana: 名(ふりがな)
         full_name: 氏名
         full_name_kana: ふりがな
+        rank: 段位
       admin:
         name: 氏名
         email: メールアドレス

--- a/test/fixtures/tournament_classes.yml
+++ b/test/fixtures/tournament_classes.yml
@@ -1,0 +1,14 @@
+advanced_class:
+  tournament: shiga
+  name:       上級者の部
+  fee:        1500
+
+d_class:
+  tournament: shiga
+  name:       D級
+  fee:        1000
+
+e_class:
+  tournament: shiga
+  name:       E級
+  fee:        1000

--- a/test/integration/entry_flow_test.rb
+++ b/test/integration/entry_flow_test.rb
@@ -2,51 +2,43 @@ require 'test_helper'
 
 class EntryFlowTest < ActionDispatch::IntegrationTest
   def setup
+    @tournament = tournaments(:shiga)
+    @tournament_class = @tournament.tournament_classes.first
     @team = teams(:kyoto)
     sign_in_as @team
   end
 
   test "invalid information" do
-    get entries_team_path(rank: "C")
+    get entries_team_path(tournament_id: @tournament.id)
     assert_no_difference 'Player.count' do
-      post entries_team_path(rank: "C"), params: {
-        players: [
-          {
+      post entries_team_path(tournament_id: @tournament.id), params: {
+        tournament_class_id: 100,
+        player: {
             last_name: " ",
             first_name: "あ"*31,
             last_name_kana: "ABC",
-            first_name_kana: "漢字"
-          },
-          {
-            last_name: "鈴木",
-            first_name: "一郎",
-            last_name_kana: "すずき",
-            first_name_kana: "いちろう"
-          }
-        ]
+            first_name_kana: "漢字",
+            rank: 20,
+            extra_attributes: []
+        }
       }
     end
     assert_select 'div .alert'
   end
 
   test "valid information" do
-    get entries_team_path(rank: "C")
-    assert_difference 'Player.count', 2 do
-      post entries_team_path(rank: "C"), params: {
-        players: [
-          {
-            last_name: "田中",
-            first_name: "一",
-            last_name_kana: "たなか",
-            first_name_kana: "はじめ"
-          },
-          {
+    get entries_team_path(tournament_id: @tournament.id)
+    assert_difference [ 'Player.count', '@tournament_class.players.count' ], 1 do
+      post entries_team_path(tournament_id: @tournament.id), params: {
+        tournament_class_id: @tournament_class.id,
+        player: {
             last_name: "鈴木",
             first_name: "一郎",
             last_name_kana: "すずき",
-            first_name_kana: "いちろう"
-          }
-        ]
+            first_name_kana: "いちろう",
+            rank: 2,
+            extra_attributes: '{}'
+        }
       }
     end
     assert flash[:success].present?


### PR DESCRIPTION
単一の`Player`を登録する機能を実装しました.

選手情報の登録と同時に, `tournament_class`とのassociationも保存するようにしてあります.

`tournament_id`をクエリ文字列で指定するようになっていますが, それが不正であるときの挙動は以下のどちらが良いのでしょうか？
- `Tournament.find`を使ってRecordNotFoundエラーを発生させる(現在の実装)
- `require_valid_tournament_id`のようなbefore_actionを定義して, 例外処理をする
