### PR TITLE
Fix queries

### DIFF
--- a/app/controllers/admin/players_controller.rb
+++ b/app/controllers/admin/players_controller.rb
@@ -4,7 +4,7 @@ class Admin::PlayersController < ApplicationController
 
   def index
     @tournament_classes = TournamentClass
-      .eager_load(:players)
+      .eager_load(players: [:team])
       .find_and_order_by_id(
         tournament_id: current_tournament.id,
         tournament_class_id: params[:tournament_class_id]

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -3,22 +3,15 @@ class Player < ApplicationRecord
   has_and_belongs_to_many :tournament_classes, join_table: :tournament_classes_players
 
   scope :default_query, -> (admin:, team_id: nil){
-    base_filtering = where(
-      deleted: [false, nil]
-    )
     base_sorting = order(
       "rank DESC",
       "last_name_kana",
       "first_name_kana"
     )
     if admin
-      base_filtering
-        .merge(base_sorting)
-        .order(:team_id)
+        order(:team_id).merge(base_sorting)
     else
-      base_filtering
-        .where(team_id: [ team_id, nil ])
-        .merge(base_sorting)
+        base_sorting.where(team_id: [ team_id, nil ])
     end
   }
 

--- a/app/models/tournament_class.rb
+++ b/app/models/tournament_class.rb
@@ -1,6 +1,8 @@
 class TournamentClass < ApplicationRecord
   belongs_to :tournament
-  has_and_belongs_to_many :players, join_table: :tournament_classes_players
+  has_and_belongs_to_many :players,
+                          -> { where(deleted: false) },
+                          join_table: :tournament_classes_players
 
   scope :find_and_order_by_id, -> (tournament_id:, tournament_class_id: nil) {
     base_query = where(tournament_id: tournament_id)

--- a/app/views/admin/players/index.html.erb
+++ b/app/views/admin/players/index.html.erb
@@ -6,7 +6,7 @@
 
     <% @tournament_classes.each do |t_class| %>
       <h3 class="mt-5">
-        <%= t_class.name %><%= "(#{t_class.players.count}名)" %>  <%= link_to 'csv出力', admin_root_path(tournament_class_id: t_class.id, format: :csv), class: 'btn btn-sm btn-info' %>
+        <%= t_class.name %><%= "(#{t_class.players.size}名)" %>  <%= link_to 'csv出力', admin_root_path(tournament_class_id: t_class.id, format: :csv), class: 'btn btn-sm btn-info' %>
       </h3>
       <table class="table">
         <tr>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,7 @@
   <% @tournament_classes.each do |tournament_class| %>
     <div class="row justify-content-center mt-5">
       <div class="col-8">
-        <h3><%= tournament_class.name %><%= "(#{tournament_class.players.count}名)" %></h3>
+        <h3><%= tournament_class.name %><%= "(#{tournament_class.players.size}名)" %></h3>
         <% if tournament_class.players.empty? %>
           申込者はいません
         <% else %>


### PR DESCRIPTION
クエリメソッドをいくつか修正しました.

1. 以下のようなコードだと`WHERE`句に論理削除されたかどうかの条件が入ってしまいます.
すると論理削除された選手のレコードしか持たない開催級が, 取得されなくなってしまいます.
```ruby
TournamentClass
  .eager_load(:players)
  .where(players: { deleted: [false, nil] })
```
`has_and_belongs_to_many`メソッドにスコープを定義することで, 論理削除されたかどうかの条件を`ON`句にもっていくことができました. 

2. レコード数を取得するための`count`メソッドは, クエリを再発行して全件数を数えてしまいます. キャッシュされたレコード数を数えるために`size`メソッドに修正しました.

3. 管理者トップページにおいて`team`をeager loadし忘れていたので修正しました.